### PR TITLE
Fix aircall get resource owner URL

### DIFF
--- a/src/Provider/Aircall.php
+++ b/src/Provider/Aircall.php
@@ -50,7 +50,7 @@ class Aircall extends AbstractProvider
      */
     public function getResourceOwnerDetailsUrl(AccessToken $token)
     {
-        return 'https://api.aircall.io/v1/integrations/me/';
+        return 'https://api.aircall.io/v1/integrations/me';
     }
 
     /**


### PR DESCRIPTION
Aircall apparently now uses much stricter URL routing. This trailing slash broke the "get resource owner" request.