### PR TITLE
Allow ResourceOwner ID to be mixed, i.e. string, int or null.

### DIFF
--- a/src/Provider/AircallResourceOwner.php
+++ b/src/Provider/AircallResourceOwner.php
@@ -31,9 +31,9 @@ class AircallResourceOwner implements ResourceOwnerInterface
     /**
      * Get resource owner id
      *
-     * @return string|null
+     * @return mixed
      */
-    public function getId(): ?string
+    public function getId()
     {
         return $this->getValueByKey($this->response, 'integration.user.id');
     }


### PR DESCRIPTION
Aircall now uses Integer as Resource Owner Id. This fix prevents cast errors. 

Related sentry issue: https://jiminny.sentry.io/issues/4984331438/